### PR TITLE
fix: Support UTF-8 characters in claude-trace HTML reports

### DIFF
--- a/apps/claude-trace/frontend/template.html
+++ b/apps/claude-trace/frontend/template.html
@@ -9,7 +9,7 @@
     <div id="app"></div>
     
     <script>
-      window.claudeData = JSON.parse(atob('__CLAUDE_LOGGER_DATA_REPLACEMENT_UNIQUE_9487__'));
+      window.claudeData = JSON.parse(decodeURIComponent(escape(atob('__CLAUDE_LOGGER_DATA_REPLACEMENT_UNIQUE_9487__'))));
     </script>
     
     <script>


### PR DESCRIPTION
## Summary
- Fixes Unicode character corruption in claude-trace HTML reports
- Replaces `atob()` with UTF-8-aware base64 decoding
- Affects Japanese, Chinese, Arabic, Russian, emojis, and accented characters

## Problem
The original code used `atob()` to decode base64 data, which treats the result as binary strings. This caused Unicode characters to be corrupted when displayed in the HTML viewer.

### Steps to reproduce

1: create a conversation that contains non-ASCII characters, or create a dummy conversation jsonl

<details>
<summary>dummy jsonl</summary>

```jsonl
{
  "request": {
    "timestamp": 1749365287.202,
    "method": "POST",
    "url": "https://api.anthropic.com/v1/messages",
    "headers": {
      "content-type": "application/json"
    },
    "body": {
      "model": "claude-3-5-sonnet-20241022",
      "max_tokens": 100,
      "messages": [
        {
          "role": "user",
          "content": "Test Unicode: 日本語 (Japanese), 中文 (Chinese), العربية (Arabic), Русский (Russian), 🚀🎉💯 (Emojis), Ñoño café naïve résumé"
        }
      ]
    }
  },
  "response": {
    "timestamp": 1749365288.047,
    "status_code": 200,
    "headers": {
      "content-type": "application/json"
    },
    "body": {
      "id": "msg_test",
      "type": "message",
      "role": "assistant",
      "model": "claude-3-5-sonnet-20241022",
      "content": [
        {
          "type": "text",
          "text": "I can see various Unicode characters:\n- Japanese: 日本語\n- Chinese: 中文\n- Arabic: العربية\n- Russian: Русский\n- Emojis: 🚀🎉💯\n- Accented Latin: Ñoño café naïve résumé"
        }
      ],
      "stop_reason": "end_turn",
      "usage": {
        "input_tokens": 50,
        "output_tokens": 30
      }
    }
  },
  "logged_at": "2025-06-08T06:48:08.309Z"
}
```
</details>

2: convert to html by `claude-trace`

### expected behaviour:

All characters are displayed correctly

![image](https://github.com/user-attachments/assets/1d14233b-0ec4-450b-9ab3-af994094f18f)

### current behaviour:

Non-ASCII characters are not displayed correctly.

![image](https://github.com/user-attachments/assets/ca876633-50a7-499c-b3d4-f1a604a703b2)

## Solution
Use `decodeURIComponent(escape(atob()))` pattern for proper UTF-8 decoding of base64 data. This is a lightweight, well-established method for handling UTF-8 encoded base64 strings in JavaScript.