### PR TITLE
fix: added lint config for README to make the rules a bit less strict…

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,11 @@
+// markdown lint file
+{
+  "MD041": false,
+  "MD010": false,
+  "MD007": false,
+  "MD012": false,
+  "MD013": false,
+  "MD024": false,
+  "MD034": false,
+  "MD036": false
+}


### PR DESCRIPTION
Being your average ADHD victim my goal is always to remove "squigglies" and your README.md has a number of deviations from the core Markdown rules (which is stupidly strict by default). Anyway, I just added this linter file for folks want a clear view of the README. Totally up to you whether you think this is added clutter or a great idea. :) 