### PR TITLE
feat: support custom ANTHROPIC_BASE_URL environment variable

### DIFF
--- a/apps/claude-trace/src/interceptor.ts
+++ b/apps/claude-trace/src/interceptor.ts
@@ -50,11 +50,15 @@ export class ClaudeTrafficLogger {
 		const urlString = typeof url === "string" ? url : url.toString();
 		const includeAllRequests = process.env.CLAUDE_TRACE_INCLUDE_ALL_REQUESTS === "true";
 
+		// Support custom ANTHROPIC_BASE_URL
+      		const baseUrl = process.env.ANTHROPIC_BASE_URL || "https://api.anthropic.com";
+      		const apiHost = new URL(baseUrl).hostname;
+		
 		if (includeAllRequests) {
-			return urlString.includes("api.anthropic.com"); // Capture all Anthropic API requests
+			return urlString.includes(apiHost); // Capture all Anthropic API requests
 		}
 
-		return urlString.includes("api.anthropic.com") && urlString.includes("/v1/messages");
+		return urlString.includes(apiHost) && urlString.includes("/v1/messages");
 	}
 
 	private generateRequestId(): string {


### PR DESCRIPTION
Add support for configuring custom Anthropic API endpoints via the ANTHROPIC_BASE_URL environment variable.

  The interceptor now reads ANTHROPIC_BASE_URL and uses its hostname to determine which requests to intercept, falling back to the
   default api.anthropic.com if not set. This enables claude-trace to work with custom API endpoints or proxy configurations.

  Changes:
  - Extract hostname from ANTHROPIC_BASE_URL or default endpoint
  - Use configured hostname for API request detection
  - No additional dependencies required (uses built-in URL constructor)