### PR TITLE
On some node version, latest claude-bridge throws No cli found issue, but that's because dynamic import of child_process failed

### DIFF
--- a/apps/claude-bridge/src/cli.ts
+++ b/apps/claude-bridge/src/cli.ts
@@ -22,7 +22,7 @@ import {
 	validateProvider,
 	type ModelValidationConfig,
 } from "@mariozechner/lemmy-cli-args";
-import { spawnSync } from "child_process";
+import { spawnSync, execSync } from "child_process";
 import path from "path";
 import { fileURLToPath } from "url";
 import { patchClaudeBinary } from "./patch-claude.js";
@@ -465,8 +465,7 @@ function findClaudeExecutable(customPath?: string): string {
 		return resolveToJsFile(customPath);
 	}
 	try {
-		let claudePath = require("child_process")
-			.execSync("which claude", {
+		let claudePath = execSync("which claude", {
 				encoding: "utf-8",
 			})
 			.trim();


### PR DESCRIPTION
<img width="1810" height="688" alt="image" src="https://github.com/user-attachments/assets/f31fd586-9806-4d96-b3e4-6b59159d356b" />
