### PR TITLE
chore: fix api Error when ANTHROPIC_BASE_URL env is empty

### DIFF
--- a/apps/claude-bridge/src/utils/request-parser.ts
+++ b/apps/claude-bridge/src/utils/request-parser.ts
@@ -111,7 +111,7 @@ export async function parseResponse(response: Response): Promise<{
  */
 export function isAnthropicAPI(url: string): boolean {
 	return (
-		url.includes(process.env.ANTHROPIC_BASE_URL.replace(/https:\/\//g, "") || "api.anthropic.com") &&
+		url.includes(process.env["ANTHROPIC_BASE_URL"]?.replace(/https:\/\//g, "") || "api.anthropic.com") &&
 		url.includes("/v1/messages")
 	);
 }


### PR DESCRIPTION
Now the cli execution will 100% meet api error if not set ANTHROPIC_BASE_URL. The root cause comes from request-parser.ts#isAnthropicAPI()  When ANTHROPIC_BASE_URL from environment variable not set, all request will be blocked and show as this
```
API Error (Connection error.) · Retrying in 1 seconds… (attempt 1/10)
    ⎿  TypeError (Cannot read properties of undefined (reading 'replace'))
```