### PR TITLE
[Proposal] chore: add json repair when model return invalid json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5651,6 +5651,15 @@
 				"graceful-fs": "^4.1.6"
 			}
 		},
+		"node_modules/jsonrepair": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.13.0.tgz",
+			"integrity": "sha512-5YRzlAQ7tuzV1nAJu3LvDlrKtBFIALHN2+a+I1MGJCt3ldRDBF/bZuvIPzae8Epot6KBXd0awRZZcuoeAsZ/mw==",
+			"license": "ISC",
+			"bin": {
+				"jsonrepair": "bin/cli.js"
+			}
+		},
 		"node_modules/jwa": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -10233,6 +10242,7 @@
 				"@google/genai": "^1.0.1",
 				"@modelcontextprotocol/sdk": "^1.12.0",
 				"chalk": "^5.4.1",
+				"jsonrepair": "^3.13.0",
 				"openai": "^4.103.0",
 				"zod": "^3.25.28",
 				"zod-to-json-schema": "^3.22.0"

--- a/packages/lemmy/package.json
+++ b/packages/lemmy/package.json
@@ -32,7 +32,8 @@
 		"chalk": "^5.4.1",
 		"openai": "^4.103.0",
 		"zod": "^3.25.28",
-		"zod-to-json-schema": "^3.22.0"
+		"zod-to-json-schema": "^3.22.0",
+		"jsonrepair": "^3.13.0"
 	},
 	"devDependencies": {
 		"@types/node": "^20.0.0",

--- a/packages/lemmy/src/clients/openai.ts
+++ b/packages/lemmy/src/clients/openai.ts
@@ -17,6 +17,7 @@ import type { OpenAIConfig, OpenAIAskOptions } from "../configs.js";
 import { zodToOpenAI } from "../tools/zod-converter.js";
 import { calculateTokenCost, findModelData } from "../index.js";
 import type { ToolDefinition } from "../types.js";
+import jsonreparser from "jsonrepair";
 
 export class OpenAIClient implements ChatClient<OpenAIAskOptions> {
 	private openai: OpenAI;
@@ -324,7 +325,7 @@ export class OpenAIClient implements ChatClient<OpenAIAskOptions> {
 						if (argsString.trim() === "") {
 							argsString = "{}";
 						}
-						const parsedArgs = JSON.parse(argsString);
+						const parsedArgs = JSON.parse(jsonreparser(argsString));
 						toolCalls.push({
 							id: toolCallData.id,
 							name: toolCallData.name,


### PR DESCRIPTION
Hi team,

we know that when model generate jsons it sometimes throws an invalid json string which could stop all actions and pollute context which makes users have to clear all memorys and redo everything from start. Actually inside of Claude-code they have some way to process it (even claude could also sometimg make this mistake) , but when use claude-bridge, it will throw eariler. So I suggest we may do the same thing as agent internally do. Or shall we return the raw string to agent directly but not parse it from our end? Which should also solve the problem

<img width="1056" height="776" alt="image" src="https://github.com/user-attachments/assets/f8a6fac6-d07d-425d-b605-29ab372c172c" />
