### PR TITLE
claude-trace: skip pairs with empty request bodies

### DIFF
--- a/apps/claude-trace/src/shared-conversation-processor.ts
+++ b/apps/claude-trace/src/shared-conversation-processor.ts
@@ -66,7 +66,7 @@ export class SharedConversationProcessor {
 
         for (let i = 0; i < rawPairs.length; i++) {
             const pair = rawPairs[i];
-            if (!pair?.request || !pair?.response) {
+            if (!pair?.request || !pair.request?.body || !pair?.response) {
                 continue;
             }
 


### PR DESCRIPTION
This fixes #38 by ignoring the empty `/api/hello` requests entirely