### PR TITLE
feat(claude-trace): Add support for native bun binary

### DIFF
--- a/apps/claude-trace/src/cli.ts
+++ b/apps/claude-trace/src/cli.ts
@@ -152,22 +152,53 @@ function resolveToJsFile(filePath: string): string {
 	}
 }
 
+// Resolve bash wrappers and return JS entry point (for Node interceptor)
 function getClaudeAbsolutePath(customPath?: string): string {
-	// If custom path is provided, use it directly
+	const claudePath = findClaudePath(customPath);
+	const isWindows = process.platform === "win32";
+
+	// Check if the path is a bash wrapper (Unix only)
+	if (!isWindows && fs.existsSync(claudePath)) {
+		const content = fs.readFileSync(claudePath, "utf-8");
+		if (content.startsWith("#!/bin/bash")) {
+			const execMatch = content.match(/exec\s+"([^"]+)"/);
+			if (execMatch && execMatch[1]) {
+				return resolveToJsFile(execMatch[1]);
+			}
+		}
+	}
+
+	return resolveToJsFile(claudePath);
+}
+
+// Get raw binary path (for native binary detection)
+function getClaudeBinaryPath(customPath?: string): string {
+	return fs.realpathSync(findClaudePath(customPath));
+}
+
+// Shared logic to find Claude binary path
+function findClaudePath(customPath?: string): string {
 	if (customPath) {
 		if (!fs.existsSync(customPath)) {
 			log(`Claude binary not found at specified path: ${customPath}`, "red");
 			process.exit(1);
 		}
-		return resolveToJsFile(customPath);
+		return customPath;
 	}
 
+	const os = require("os");
+	const isWindows = process.platform === "win32";
+
 	try {
+		const findCmd = isWindows ? "where claude" : "which claude";
 		let claudePath = require("child_process")
-			.execSync("which claude", {
-				encoding: "utf-8",
-			})
+			.execSync(findCmd, { encoding: "utf-8" })
 			.trim();
+
+		// Windows 'where' can return multiple lines, take the first
+		if (isWindows && claudePath.includes("\n")) {
+			claudePath = claudePath.split("\n")[0].trim();
+		}
 
 		// Handle shell aliases (e.g., "claude: aliased to /path/to/claude")
 		const aliasMatch = claudePath.match(/:\s*aliased to\s+(.+)$/);
@@ -175,44 +206,30 @@ function getClaudeAbsolutePath(customPath?: string): string {
 			claudePath = aliasMatch[1];
 		}
 
-		// Check if the path is a bash wrapper
-		if (fs.existsSync(claudePath)) {
-			const content = fs.readFileSync(claudePath, "utf-8");
-			if (content.startsWith("#!/bin/bash")) {
-				// Parse bash wrapper to find actual executable
-				const execMatch = content.match(/exec\s+"([^"]+)"/);
-				if (execMatch && execMatch[1]) {
-					const actualPath = execMatch[1];
-					// Resolve any symlinks to get the final JS file
-					return resolveToJsFile(actualPath);
-				}
+		return claudePath;
+	} catch {
+		// Check common installation locations
+		const possiblePaths = isWindows
+			? [
+				path.join(os.homedir(), ".local", "bin", "claude.exe"),
+				path.join(process.env.APPDATA || "", "npm", "claude.cmd"),
+			]
+			: [
+				path.join(os.homedir(), ".claude", "bin", "claude"),
+				path.join(os.homedir(), ".claude", "local", "claude"),
+				path.join(os.homedir(), ".local", "bin", "claude"),
+				"/opt/homebrew/bin/claude",
+				"/usr/local/bin/claude",
+				"/usr/bin/claude",
+			];
+
+		for (const p of possiblePaths) {
+			if (fs.existsSync(p)) {
+				return p;
 			}
 		}
 
-		return resolveToJsFile(claudePath);
-	} catch (error) {
-		// First try the local bash wrapper
-		const os = require("os");
-		const localClaudeWrapper = path.join(os.homedir(), ".claude", "local", "claude");
-
-		if (fs.existsSync(localClaudeWrapper)) {
-			const content = fs.readFileSync(localClaudeWrapper, "utf-8");
-			if (content.startsWith("#!/bin/bash")) {
-				const execMatch = content.match(/exec\s+"([^"]+)"/);
-				if (execMatch && execMatch[1]) {
-					return resolveToJsFile(execMatch[1]);
-				}
-			}
-		}
-
-		// Then try the node_modules/.bin path
-		const localClaudePath = path.join(os.homedir(), ".claude", "local", "node_modules", ".bin", "claude");
-		if (fs.existsSync(localClaudePath)) {
-			return resolveToJsFile(localClaudePath);
-		}
-
-		log(`Claude CLI not found in PATH`, "red");
-		log(`Also checked for local installation at: ${localClaudeWrapper}`, "red");
+		log(`Claude CLI not found in PATH or common locations`, "red");
 		log(`Please install Claude Code CLI first`, "red");
 		process.exit(1);
 	}
@@ -271,53 +288,6 @@ function isNativeBinary(filePath: string): boolean {
 		return false;
 	} catch {
 		return false;
-	}
-}
-
-function getClaudeBinaryPath(customPath?: string): string {
-	// If custom path is provided, use it directly
-	if (customPath) {
-		if (!fs.existsSync(customPath)) {
-			log(`Claude binary not found at specified path: ${customPath}`, "red");
-			process.exit(1);
-		}
-		return fs.realpathSync(customPath);
-	}
-
-	try {
-		let claudePath = require("child_process")
-			.execSync("which claude", {
-				encoding: "utf-8",
-			})
-			.trim();
-
-		// Handle shell aliases
-		const aliasMatch = claudePath.match(/:\s*aliased to\s+(.+)$/);
-		if (aliasMatch && aliasMatch[1]) {
-			claudePath = aliasMatch[1];
-		}
-
-		// Resolve symlinks
-		return fs.realpathSync(claudePath);
-	} catch {
-		// Check common locations
-		const os = require("os");
-		const possiblePaths = [
-			path.join(os.homedir(), ".local", "bin", "claude"),
-			path.join(os.homedir(), ".claude", "local", "claude"),
-			"/usr/local/bin/claude",
-			"/usr/bin/claude",
-		];
-
-		for (const p of possiblePaths) {
-			if (fs.existsSync(p)) {
-				return fs.realpathSync(p);
-			}
-		}
-
-		log(`Claude CLI not found in PATH or common locations`, "red");
-		log(`Please install Claude Code CLI first`, "red");
-		process.exit(1);
 	}
 }
 

--- a/apps/claude-trace/src/cli.ts
+++ b/apps/claude-trace/src/cli.ts
@@ -4,6 +4,7 @@ import { spawn, ChildProcess } from "child_process";
 import * as path from "path";
 import * as fs from "fs";
 import { HTMLGenerator } from "./html-generator";
+import { ReverseProxyServer } from "./reverse-proxy";
 
 // Colors for output
 export const colors = {
@@ -34,6 +35,7 @@ ${colors.yellow}OPTIONS:${colors.reset}
   --index           Generate conversation summaries and index for .claude-trace/ directory
   --run-with         Pass all following arguments to Claude process
   --include-all-requests Include all requests made through fetch, otherwise only requests to v1/messages with more than 2 messages in the context
+  --include-sensitive-headers Log sensitive headers (auth tokens, cookies) without redaction
   --no-open          Don't open generated HTML file in browser
   --log              Specify custom log file base name (without extension)
   --claude-path      Specify custom path to Claude binary
@@ -227,6 +229,184 @@ function getLoaderPath(): string {
 	return loaderPath;
 }
 
+// Magic bytes for detecting native binaries
+const NATIVE_BINARY_SIGNATURES = {
+	ELF: Buffer.from([0x7f, 0x45, 0x4c, 0x46]), // Linux ELF
+	MACHO_32: Buffer.from([0xfe, 0xed, 0xfa, 0xce]), // macOS Mach-O 32-bit
+	MACHO_64: Buffer.from([0xfe, 0xed, 0xfa, 0xcf]), // macOS Mach-O 64-bit
+	MACHO_32_REV: Buffer.from([0xce, 0xfa, 0xed, 0xfe]), // macOS Mach-O 32-bit (reverse)
+	MACHO_64_REV: Buffer.from([0xcf, 0xfa, 0xed, 0xfe]), // macOS Mach-O 64-bit (reverse)
+	MACHO_FAT: Buffer.from([0xca, 0xfe, 0xba, 0xbe]), // macOS Mach-O fat binary
+	PE: Buffer.from([0x4d, 0x5a]), // Windows PE (MZ header)
+};
+
+function isNativeBinary(filePath: string): boolean {
+	try {
+		const fd = fs.openSync(filePath, "r");
+		const buffer = Buffer.alloc(4);
+		fs.readSync(fd, buffer, 0, 4, 0);
+		fs.closeSync(fd);
+
+		// Check for ELF (Linux)
+		if (buffer.subarray(0, 4).equals(NATIVE_BINARY_SIGNATURES.ELF)) {
+			return true;
+		}
+
+		// Check for Mach-O (macOS)
+		if (
+			buffer.subarray(0, 4).equals(NATIVE_BINARY_SIGNATURES.MACHO_32) ||
+			buffer.subarray(0, 4).equals(NATIVE_BINARY_SIGNATURES.MACHO_64) ||
+			buffer.subarray(0, 4).equals(NATIVE_BINARY_SIGNATURES.MACHO_32_REV) ||
+			buffer.subarray(0, 4).equals(NATIVE_BINARY_SIGNATURES.MACHO_64_REV) ||
+			buffer.subarray(0, 4).equals(NATIVE_BINARY_SIGNATURES.MACHO_FAT)
+		) {
+			return true;
+		}
+
+		// Check for PE (Windows)
+		if (buffer.subarray(0, 2).equals(NATIVE_BINARY_SIGNATURES.PE)) {
+			return true;
+		}
+
+		return false;
+	} catch {
+		return false;
+	}
+}
+
+function getClaudeBinaryPath(customPath?: string): string {
+	// If custom path is provided, use it directly
+	if (customPath) {
+		if (!fs.existsSync(customPath)) {
+			log(`Claude binary not found at specified path: ${customPath}`, "red");
+			process.exit(1);
+		}
+		return fs.realpathSync(customPath);
+	}
+
+	try {
+		let claudePath = require("child_process")
+			.execSync("which claude", {
+				encoding: "utf-8",
+			})
+			.trim();
+
+		// Handle shell aliases
+		const aliasMatch = claudePath.match(/:\s*aliased to\s+(.+)$/);
+		if (aliasMatch && aliasMatch[1]) {
+			claudePath = aliasMatch[1];
+		}
+
+		// Resolve symlinks
+		return fs.realpathSync(claudePath);
+	} catch {
+		// Check common locations
+		const os = require("os");
+		const possiblePaths = [
+			path.join(os.homedir(), ".local", "bin", "claude"),
+			path.join(os.homedir(), ".claude", "local", "claude"),
+			"/usr/local/bin/claude",
+			"/usr/bin/claude",
+		];
+
+		for (const p of possiblePaths) {
+			if (fs.existsSync(p)) {
+				return fs.realpathSync(p);
+			}
+		}
+
+		log(`Claude CLI not found in PATH or common locations`, "red");
+		log(`Please install Claude Code CLI first`, "red");
+		process.exit(1);
+	}
+}
+
+// Run Claude as a native binary with reverse proxy interception
+async function runClaudeNativeWithProxy(
+	claudePath: string,
+	claudeArgs: string[] = [],
+	includeAllRequests: boolean = false,
+	openInBrowser: boolean = false,
+	logBaseName?: string,
+	logSensitiveHeaders: boolean = false,
+): Promise<void> {
+	log("Using reverse proxy mode for native binary", "yellow");
+	console.log("");
+
+	// Start the reverse proxy
+	const proxy = new ReverseProxyServer({
+		logBaseName: logBaseName,
+		includeAllRequests: includeAllRequests,
+		openBrowser: openInBrowser,
+		logSensitiveHeaders: logSensitiveHeaders,
+	});
+
+	let proxyInfo: { port: number; url: string };
+	try {
+		proxyInfo = await proxy.start();
+		log(`Reverse proxy started at ${proxyInfo.url}`, "green");
+		console.log("");
+	} catch (error) {
+		const err = error as Error;
+		log(`Failed to start reverse proxy: ${err.message}`, "red");
+		process.exit(1);
+	}
+
+	// Spawn Claude with ANTHROPIC_BASE_URL pointing to our HTTP proxy
+	// Using HTTP avoids TLS certificate issues with Bun binaries
+	const child: ChildProcess = spawn(claudePath, claudeArgs, {
+		env: {
+			...process.env,
+			ANTHROPIC_BASE_URL: proxyInfo.url,
+		},
+		stdio: "inherit",
+		cwd: process.cwd(),
+	});
+
+	// Handle child process events
+	child.on("error", (error: Error) => {
+		proxy.stop();
+		log(`Error starting Claude: ${error.message}`, "red");
+		process.exit(1);
+	});
+
+	child.on("exit", (code: number | null, signal: string | null) => {
+		proxy.stop();
+		if (signal) {
+			log(`\nClaude terminated by signal: ${signal}`, "yellow");
+		} else if (code !== 0 && code !== null) {
+			log(`\nClaude exited with code: ${code}`, "yellow");
+		} else {
+			log("\nClaude session completed", "green");
+		}
+	});
+
+	// Handle our own signals
+	const handleSignal = (signal: string) => {
+		log(`\nReceived ${signal}, shutting down...`, "yellow");
+		proxy.stop();
+		if (child.pid) {
+			child.kill(signal as NodeJS.Signals);
+		}
+	};
+
+	process.on("SIGINT", () => handleSignal("SIGINT"));
+	process.on("SIGTERM", () => handleSignal("SIGTERM"));
+
+	// Wait for child process to complete
+	try {
+		await new Promise<void>((resolve, reject) => {
+			child.on("exit", () => resolve());
+			child.on("error", reject);
+		});
+	} catch (error) {
+		const err = error as Error;
+		proxy.stop();
+		log(`Unexpected error: ${err.message}`, "red");
+		process.exit(1);
+	}
+}
+
 // Scenario 1: No args -> launch node with interceptor and absolute path to claude
 async function runClaudeWithInterception(
 	claudeArgs: string[] = [],
@@ -234,6 +414,7 @@ async function runClaudeWithInterception(
 	openInBrowser: boolean = false,
 	customClaudePath?: string,
 	logBaseName?: string,
+	logSensitiveHeaders: boolean = false,
 ): Promise<void> {
 	log("Claude Trace", "blue");
 	log("Starting Claude with traffic logging", "yellow");
@@ -242,15 +423,27 @@ async function runClaudeWithInterception(
 	}
 	console.log("");
 
-	const claudePath = getClaudeAbsolutePath(customClaudePath);
+	// Get the binary path and check if it's a native binary
+	const claudePath = getClaudeBinaryPath(customClaudePath);
+	log(`Using Claude binary: ${claudePath}`, "blue");
+
+	// Check if this is a native binary (ELF, Mach-O, PE)
+	if (isNativeBinary(claudePath)) {
+		log("Detected native binary", "yellow");
+		await runClaudeNativeWithProxy(claudePath, claudeArgs, includeAllRequests, openInBrowser, logBaseName, logSensitiveHeaders);
+		return;
+	}
+
+	// For Node.js-based Claude, use the original interceptor approach
+	const jsPath = resolveToJsFile(claudePath);
 	const loaderPath = getLoaderPath();
 
-	log(`Using Claude binary: ${claudePath}`, "blue");
+	log(`Using JavaScript entry: ${jsPath}`, "blue");
 	log("Starting traffic logger...", "green");
 	console.log("");
 
 	// Launch node with interceptor and absolute path to claude, plus any additional arguments
-	const spawnArgs = ["--require", loaderPath, claudePath, ...claudeArgs];
+	const spawnArgs = ["--require", loaderPath, jsPath, ...claudeArgs];
 	const child: ChildProcess = spawn("node", spawnArgs, {
 		env: {
 			...process.env,
@@ -487,6 +680,9 @@ async function main(): Promise<void> {
 		logBaseName = claudeTraceArgs[logIndex + 1];
 	}
 
+	// Check for sensitive headers logging flag
+	const logSensitiveHeaders = claudeTraceArgs.includes("--include-sensitive-headers");
+
 	// Scenario 2: --extract-token
 	if (claudeTraceArgs.includes("--extract-token")) {
 		await extractToken(customClaudePath);
@@ -525,7 +721,7 @@ async function main(): Promise<void> {
 	}
 
 	// Scenario 1: No args (or claude with args) -> launch claude with interception
-	await runClaudeWithInterception(claudeArgs, includeAllRequests, openInBrowser, customClaudePath, logBaseName);
+	await runClaudeWithInterception(claudeArgs, includeAllRequests, openInBrowser, customClaudePath, logBaseName, logSensitiveHeaders);
 }
 
 main().catch((error) => {

--- a/apps/claude-trace/src/reverse-proxy.ts
+++ b/apps/claude-trace/src/reverse-proxy.ts
@@ -2,8 +2,10 @@ import * as https from "https";
 import * as http from "http";
 import * as fs from "fs";
 import * as path from "path";
-import { RawPair } from "./types";
+import * as zlib from "zlib";
+import { RawPair, SSEEvent } from "./types";
 import { HTMLGenerator } from "./html-generator";
+import { SharedConversationProcessor } from "./shared-conversation-processor";
 
 export interface ReverseProxyConfig {
 	port?: number;
@@ -82,6 +84,32 @@ export class ReverseProxyServer {
 		return result;
 	}
 
+	private parseSSEEvents(body: string): SSEEvent[] {
+		const events: SSEEvent[] = [];
+		const lines = body.split("\n");
+		let currentEvent = "";
+
+		for (const line of lines) {
+			if (line.startsWith("event: ")) {
+				currentEvent = line.substring(7).trim();
+			} else if (line.startsWith("data: ")) {
+				const data = line.substring(6).trim();
+				if (data === "[DONE]") break;
+				try {
+					const parsed = JSON.parse(data);
+					events.push({
+						event: currentEvent || parsed?.type || "unknown",
+						data: parsed,
+						timestamp: new Date().toISOString(),
+					});
+				} catch {
+					// Skip unparseable events
+				}
+			}
+		}
+		return events;
+	}
+
 	private async writePairToLog(pair: RawPair): Promise<void> {
 		try {
 			const jsonLine = JSON.stringify(pair) + "\n";
@@ -157,10 +185,10 @@ export class ReverseProxyServer {
 
 			const proxyReq = https.request(options, (proxyRes) => {
 				const responseTimestamp = Date.now();
-				let responseBody = "";
+				const responseChunks: Buffer[] = [];
 
 				proxyRes.on("data", (chunk) => {
-					responseBody += chunk;
+					responseChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
 					res.write(chunk);
 				});
 
@@ -181,12 +209,39 @@ export class ReverseProxyServer {
 							parsedRequestBody = requestBody || null;
 						}
 
+						// Decompress response if gzipped
+						const rawBuffer = Buffer.concat(responseChunks);
+						let responseBody: string;
+						const contentEncoding = (proxyRes.headers["content-encoding"] || "").toLowerCase();
+						try {
+							if (contentEncoding === "gzip") {
+								responseBody = zlib.gunzipSync(rawBuffer).toString("utf-8");
+							} else if (contentEncoding === "br") {
+								responseBody = zlib.brotliDecompressSync(rawBuffer).toString("utf-8");
+							} else if (contentEncoding === "deflate") {
+								responseBody = zlib.inflateSync(rawBuffer).toString("utf-8");
+							} else {
+								responseBody = rawBuffer.toString("utf-8");
+							}
+						} catch {
+							responseBody = rawBuffer.toString("utf-8");
+						}
+
 						// Parse response body
-						let parsedResponseBody: { body?: any; body_raw?: string } = {};
+						let parsedResponseBody: { body?: any; body_raw?: string; events?: SSEEvent[] } = {};
 						const contentType = proxyRes.headers["content-type"] || "";
 						try {
 							if (contentType.includes("application/json")) {
 								parsedResponseBody = { body: JSON.parse(responseBody) };
+							} else if (contentType.includes("text/event-stream")) {
+								const events = this.parseSSEEvents(responseBody);
+								const processor = new SharedConversationProcessor();
+								try {
+									const message = processor.parseStreamingResponse(responseBody);
+									parsedResponseBody = { body: message, events };
+								} catch {
+									parsedResponseBody = { body_raw: responseBody, events };
+								}
 							} else {
 								parsedResponseBody = { body_raw: responseBody };
 							}

--- a/apps/claude-trace/src/reverse-proxy.ts
+++ b/apps/claude-trace/src/reverse-proxy.ts
@@ -1,0 +1,267 @@
+import * as https from "https";
+import * as http from "http";
+import * as fs from "fs";
+import * as path from "path";
+import { RawPair } from "./types";
+import { HTMLGenerator } from "./html-generator";
+
+export interface ReverseProxyConfig {
+	port?: number;
+	logDirectory?: string;
+	logBaseName?: string;
+	includeAllRequests?: boolean;
+	openBrowser?: boolean;
+	logSensitiveHeaders?: boolean;
+}
+
+export class ReverseProxyServer {
+	private server: http.Server | null = null;
+	private config: Required<ReverseProxyConfig>;
+	private pairs: RawPair[] = [];
+	private logFile: string;
+	private htmlFile: string;
+	private htmlGenerator: HTMLGenerator;
+	private targetHost = "api.anthropic.com";
+	private targetPort = 443;
+
+	constructor(config: ReverseProxyConfig = {}) {
+		this.config = {
+			port: config.port || 0, // 0 = auto-assign
+			logDirectory: config.logDirectory || ".claude-trace",
+			logBaseName: config.logBaseName || "",
+			includeAllRequests: config.includeAllRequests || false,
+			openBrowser: config.openBrowser || false,
+			logSensitiveHeaders: config.logSensitiveHeaders || false,
+		};
+
+		// Create log directory if needed
+		if (!fs.existsSync(this.config.logDirectory)) {
+			fs.mkdirSync(this.config.logDirectory, { recursive: true });
+		}
+
+		// Generate filenames
+		const fileBaseName =
+			this.config.logBaseName ||
+			`log-${new Date().toISOString().replace(/[:.]/g, "-").replace("T", "-").slice(0, -5)}`;
+
+		this.logFile = path.join(this.config.logDirectory, `${fileBaseName}.jsonl`);
+		this.htmlFile = path.join(this.config.logDirectory, `${fileBaseName}.html`);
+
+		// Clear log file
+		fs.writeFileSync(this.logFile, "");
+
+		this.htmlGenerator = new HTMLGenerator();
+	}
+
+	private processHeaders(headers: Record<string, string | string[] | undefined>): Record<string, string> {
+		const result: Record<string, string> = {};
+		const sensitiveKeys = ["authorization", "x-api-key", "x-auth-token", "cookie", "set-cookie"];
+
+		for (const [key, value] of Object.entries(headers)) {
+			if (value === undefined) continue;
+			const strValue = Array.isArray(value) ? value.join(", ") : value;
+
+			if (this.config.logSensitiveHeaders) {
+				result[key] = strValue;
+			} else {
+				const lowerKey = key.toLowerCase();
+				if (sensitiveKeys.some((s) => lowerKey.includes(s))) {
+					if (strValue.length > 14) {
+						result[key] = `${strValue.substring(0, 10)}...${strValue.slice(-4)}`;
+					} else if (strValue.length > 4) {
+						result[key] = `${strValue.substring(0, 2)}...${strValue.slice(-2)}`;
+					} else {
+						result[key] = "[REDACTED]";
+					}
+				} else {
+					result[key] = strValue;
+				}
+			}
+		}
+
+		return result;
+	}
+
+	private async writePairToLog(pair: RawPair): Promise<void> {
+		try {
+			const jsonLine = JSON.stringify(pair) + "\n";
+			fs.appendFileSync(this.logFile, jsonLine);
+		} catch (err) {
+			console.error(`Failed to write log: ${err}`);
+		}
+	}
+
+	private async generateHTML(): Promise<void> {
+		try {
+			await this.htmlGenerator.generateHTML(this.pairs, this.htmlFile, {
+				title: `${this.pairs.length} API Calls`,
+				timestamp: new Date().toISOString().replace("T", " ").slice(0, -5),
+				includeAllRequests: this.config.includeAllRequests,
+			});
+		} catch (err) {
+			console.error(`Failed to generate HTML: ${err}`);
+		}
+	}
+
+	public async start(): Promise<{ port: number; url: string }> {
+		// Use plain HTTP to avoid TLS certificate issues with Bun binaries
+		// The proxy receives HTTP from Claude, forwards as HTTPS to Anthropic
+		return new Promise((resolve, reject) => {
+			const httpServer = http.createServer((req, res) => {
+				this.handleRequest(req, res);
+			});
+			this.server = httpServer;
+
+			httpServer.on("error", (err) => {
+				reject(err);
+			});
+
+			httpServer.listen(this.config.port, "127.0.0.1", () => {
+				const address = httpServer.address();
+				if (address && typeof address === "object") {
+					const port = address.port;
+					const url = `http://127.0.0.1:${port}`;
+
+					console.log(`Logs will be written to:`);
+					console.log(`  JSONL: ${path.resolve(this.logFile)}`);
+					console.log(`  HTML:  ${path.resolve(this.htmlFile)}`);
+
+					resolve({ port, url });
+				} else {
+					reject(new Error("Failed to get server address"));
+				}
+			});
+		});
+	}
+
+	private handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
+		const requestTimestamp = Date.now();
+		let requestBody = "";
+
+		req.on("data", (chunk) => {
+			requestBody += chunk;
+		});
+
+		req.on("end", () => {
+			// Forward the request to the real Anthropic API
+			const options: https.RequestOptions = {
+				hostname: this.targetHost,
+				port: this.targetPort,
+				path: req.url,
+				method: req.method,
+				headers: {
+					...req.headers,
+					host: this.targetHost,
+				},
+			};
+
+			const proxyReq = https.request(options, (proxyRes) => {
+				const responseTimestamp = Date.now();
+				let responseBody = "";
+
+				proxyRes.on("data", (chunk) => {
+					responseBody += chunk;
+					res.write(chunk);
+				});
+
+				proxyRes.on("end", async () => {
+					res.end();
+
+					// Check if this is a request we should log
+					const url = `https://${this.targetHost}${req.url}`;
+					const shouldLog =
+						this.config.includeAllRequests || (req.url && req.url.includes("/v1/messages"));
+
+					if (shouldLog) {
+						// Parse request body
+						let parsedRequestBody: any = null;
+						try {
+							parsedRequestBody = requestBody ? JSON.parse(requestBody) : null;
+						} catch {
+							parsedRequestBody = requestBody || null;
+						}
+
+						// Check message count filter (only log if > 2 messages)
+						if (!this.config.includeAllRequests && parsedRequestBody?.messages) {
+							if (parsedRequestBody.messages.length <= 2) {
+								return;
+							}
+						}
+
+						// Parse response body
+						let parsedResponseBody: { body?: any; body_raw?: string } = {};
+						const contentType = proxyRes.headers["content-type"] || "";
+						try {
+							if (contentType.includes("application/json")) {
+								parsedResponseBody = { body: JSON.parse(responseBody) };
+							} else {
+								parsedResponseBody = { body_raw: responseBody };
+							}
+						} catch {
+							parsedResponseBody = { body_raw: responseBody };
+						}
+
+						const pair: RawPair = {
+							request: {
+								timestamp: requestTimestamp / 1000,
+								method: req.method || "GET",
+								url: url,
+								headers: this.processHeaders(req.headers as Record<string, string>),
+								body: parsedRequestBody,
+							},
+							response: {
+								timestamp: responseTimestamp / 1000,
+								status_code: proxyRes.statusCode || 0,
+								headers: this.processHeaders(
+									proxyRes.headers as Record<string, string>,
+								),
+								...parsedResponseBody,
+							},
+							logged_at: new Date().toISOString(),
+						};
+
+						this.pairs.push(pair);
+						await this.writePairToLog(pair);
+						await this.generateHTML();
+					}
+				});
+
+				// Forward response headers
+				res.writeHead(proxyRes.statusCode || 200, proxyRes.headers);
+			});
+
+			proxyReq.on("error", (err) => {
+				console.error(`Proxy request error: ${err.message}`);
+				res.writeHead(502);
+				res.end(`Proxy error: ${err.message}`);
+			});
+
+			// Forward request body
+			if (requestBody) {
+				proxyReq.write(requestBody);
+			}
+			proxyReq.end();
+		});
+	}
+
+	public stop(): void {
+		if (this.server) {
+			console.log(`Logged ${this.pairs.length} request/response pairs`);
+
+			// Open browser if requested
+			if (this.config.openBrowser && fs.existsSync(this.htmlFile)) {
+				try {
+					const { spawn } = require("child_process");
+					const cmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
+					spawn(cmd, [this.htmlFile], { detached: true, stdio: "ignore" }).unref();
+					console.log(`Opening ${this.htmlFile} in browser`);
+				} catch (err) {
+					console.error(`Failed to open browser: ${err}`);
+				}
+			}
+
+			this.server.close();
+			this.server = null;
+		}
+	}
+}

--- a/apps/claude-trace/src/reverse-proxy.ts
+++ b/apps/claude-trace/src/reverse-proxy.ts
@@ -181,13 +181,6 @@ export class ReverseProxyServer {
 							parsedRequestBody = requestBody || null;
 						}
 
-						// Check message count filter (only log if > 2 messages)
-						if (!this.config.includeAllRequests && parsedRequestBody?.messages) {
-							if (parsedRequestBody.messages.length <= 2) {
-								return;
-							}
-						}
-
 						// Parse response body
 						let parsedResponseBody: { body?: any; body_raw?: string } = {};
 						const contentType = proxyRes.headers["content-type"] || "";

--- a/apps/claude-trace/src/shared-conversation-processor.ts
+++ b/apps/claude-trace/src/shared-conversation-processor.ts
@@ -249,7 +249,7 @@ export class SharedConversationProcessor {
     /**
      * Parse streaming response from raw SSE data
      */
-    private parseStreamingResponse(bodyRaw: string): Message {
+    public parseStreamingResponse(bodyRaw: string): Message {
         if (this.isBedrockResponse(bodyRaw)) {
             return this.parseBedrockStreamingResponse(bodyRaw);
         } else {


### PR DESCRIPTION
Adds support for tracing Claude when installed as a native binary (Bun-compiled) instead of Node.js. Uses a reverse proxy approach since the `--require` interceptor only works with Node.

- Detect native binaries via magic bytes, use HTTP reverse proxy for interception
- Add optional `--include-sensitive-headers` that logs bearer token and other credentials
- Cross-platform support (Windows/macOS/Linux) (Only Ubuntu tested so far)

I only tested it on Ubuntu Server so would be nice if someone on Mac and Windows were to test it before any possible merge.
Should resolve #37 and #48.